### PR TITLE
fix: add quotes arround table names

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -65,15 +65,15 @@ class Database {
       data[i] = record[key];
       nums[i] = `$${++i}`;
     }
-    const fields = keys.join(', ');
+    const fields = '"' + keys.join('", "') + '"';
     const params = nums.join(', ');
-    const sql = `INSERT INTO ${table} (${fields}) VALUES (${params})`;
+    const sql = `INSERT INTO "${table}" (${fields}) VALUES (${params})`;
     return this.query(sql, data);
   }
 
   async select(table, fields = ['*'], conditions = null) {
     const keys = fields.join(', ');
-    const sql = `SELECT ${keys} FROM ${table}`;
+    const sql = `SELECT ${keys} FROM "${table}"`;
     let whereClause = '';
     let args = [];
     if (conditions) {
@@ -87,14 +87,14 @@ class Database {
 
   delete(table, conditions = null) {
     const { clause, args } = where(conditions);
-    const sql = `DELETE FROM ${table} WHERE ${clause}`;
+    const sql = `DELETE FROM "${table}" WHERE ${clause}`;
     return this.query(sql, args);
   }
 
   update(table, delta = null, conditions = null) {
     const upd = updates(delta);
     const cond = where(conditions, upd.args.length + 1);
-    const sql = `UPDATE ${table} SET ${upd.clause} WHERE ${cond.clause}`;
+    const sql = `UPDATE "${table}" SET ${upd.clause} WHERE ${cond.clause}`;
     const args = [...upd.args, ...cond.args];
     return this.query(sql, args);
   }


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
