### PR TITLE
fix: correct file names in database migrations

### DIFF
--- a/lib/dbms.js
+++ b/lib/dbms.js
@@ -48,7 +48,7 @@ const getPreviousVersion = async (modelPath) => {
   return path.join(historyPath, previousName);
 };
 
-const create = async (modelPath, outputPath) => {
+const create = async (modelPath, outputPath = modelPath) => {
   console.log('Generating SQL DDL script ' + shorten(outputPath));
   const model = await loadModel(modelPath);
   const script = [];
@@ -81,8 +81,8 @@ const generate = async (modelPath) => {
     console.log('You have latest model version. Migration is not needed.');
     return;
   }
-  const newFolder = path.join(modelPath, `history/${date}-v${version}`);
-  const mig = path.join(modelPath, `migration/${date}-v${version}`);
+  const newFolder = path.join(modelPath, `history/${now}-v${version}`);
+  const mig = path.join(modelPath, `migration/${now}-v${version}`);
   const migUp = mig + '-up.sql';
   const migDn = mig + '-dn.sql';
   console.log(`Save history: ${shorten(newFolder)}`);


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
