### PR TITLE
fix: generated `always as identity` just for `Registry`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add typings for Database and Query classes
 - Move types to package root
+- Generated `always as identity` just for `Registry`
 
 ## [1.1.5][] - 2021-07-04
 

--- a/lib/pg.js
+++ b/lib/pg.js
@@ -136,7 +136,8 @@ const createEntity = (model, name) => {
   const registry = entity.kind === 'registry';
   const pkField = name === 'Identifier' ? 'id' : name + 'Id';
   const pk = registry ? 'id' : toLowerCamel(pkField);
-  sql.push(`  "${pk}" bigint generated always as identity,`);
+  const gen = registry ? 'NOT NULL' : 'generated always as identity';
+  sql.push(`  "${pk}" bigint ${gen},`);
   idx.push(primaryCustom(name, [pk]));
   if (registry) idx.push(foreignKey(name, pk, { type: 'Identifier' }));
   const flat = flatFields(entity.fields);


### PR DESCRIPTION
Closes: https://github.com/metarhia/metasql/issues/176

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
