### PR TITLE
Support DEFAULT CURRENT_TIMESTAMP for datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add typings for Database and Query classes
 - Move types to package root
 - Generated `always as identity` just for `Registry`
+- Support `DEFAULT CURRENT_TIMESTAMP` for `datetime`
 
 ## [1.1.5][] - 2021-07-04
 

--- a/lib/pg.js
+++ b/lib/pg.js
@@ -155,8 +155,12 @@ const createEntity = (model, name) => {
       let defVal = '';
       if (typeof def.default !== 'undefined') {
         defVal = ' DEFAULT ';
-        const quoted = def.type === 'number' || def.type === 'boolean';
-        defVal += quoted ? def.default : `'${def.default}'`;
+        if (def.type === 'datetime' && def.default === 'now') {
+          defVal += `CURRENT_TIMESTAMP`;
+        } else {
+          const quoted = def.type === 'number' || def.type === 'boolean';
+          defVal += quoted ? def.default : `'${def.default}'`;
+        }
       }
       if (def.length && def.length.max) {
         pgType = `${pgType}(${def.length.max})`;


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
