### PR TITLE
Generate `ON DELETE CASCADE` for `{ many }`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Use `options.logger` and global `console` if no `options.console` for backward
   compatibility, fallback will be better than crash
+- Add `{ delete: 'cascade' }` to generate `ON DELETE CASCADE` for `{ many }`
 
 ## [1.2.0][] - 2021-08-04
 

--- a/lib/pg.js
+++ b/lib/pg.js
@@ -56,13 +56,13 @@ const createIndex = (entityName, indexName, def, entity) => {
 };
 
 const createMany = (entityName, { many }, model) => {
-  const fromEntity = toLowerCamel(entityName);
-  const toEntity = toLowerCamel(many);
+  const from = toLowerCamel(entityName);
+  const to = toLowerCamel(many);
   const crossName = entityName + many;
   const crossReference = {
-    [fromEntity]: { name: fromEntity, type: entityName, required: true },
-    [toEntity]: { name: toEntity, type: many, required: true },
-    [crossName]: { name: crossName, primary: [fromEntity, toEntity] },
+    [from]: { name: from, type: entityName, delete: 'cascade', required: true },
+    [to]: { name: to, type: many, delete: 'cascade', required: true },
+    [crossName]: { name: crossName, primary: [from, to] },
   };
   const entity = new Schema(crossName, crossReference);
   model.entities.set(crossName, entity);


### PR DESCRIPTION
Closes: https://github.com/metarhia/metasql/issues/191

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
