### PR TITLE
WIP: Fix migration commands

### DIFF
--- a/lib/dbms.js
+++ b/lib/dbms.js
@@ -114,9 +114,9 @@ const create = async (modelPath, outputPath = modelPath) => {
 const createMigrations = async (migrationPath, fullVersion, cwd) => {
   const mig = path.join(migrationPath, fullVersion);
   await fsp.mkdir(mig, { recursive: true });
-  const migUp = path.join(migrationPath, `${mig}-up.sql`);
+  const migUp = path.join(mig, `${fullVersion}-up.sql`);
   await fsp.writeFile(migUp, '', { encoding: 'utf8' });
-  const migDn = path.join(migrationPath, `${mig}-dn.sql`);
+  const migDn = path.join(mig, `${fullVersion}-dn.sql`);
   await fsp.writeFile(migDn, '', { encoding: 'utf8' });
   console.log(`Migration up: ${shorten(migUp, cwd)}`);
   console.log(`Migration down: ${shorten(migDn, cwd)}`);


### PR DESCRIPTION
* on no prev version - copy current schemas as old version
* upon executing a 'g' command create a new version history and
  migration folders
* store time in migration version
* upon creating a new version copy only "changes" schemas compared
  to the old version

<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
