### PR TITLE
Add error stack info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased][unreleased]
 
+- Capture relevant error stack trace
+- Add catch function to query execution
+- Make query execution properly then-able
+
 ## [2.0.2][] - 2021-10-14
 
 - Support `null` as value for `update`

--- a/lib/database.js
+++ b/lib/database.js
@@ -121,9 +121,13 @@ class Query {
 
   then(resolve, reject) {
     const { sql, args } = this.prepare();
-    return this.db.query(sql, args).then((result) => {
-      resolve(result.rows);
-    }, reject);
+    return this.db
+      .query(sql, args)
+      .then(({ rows }) => (resolve ? resolve(rows) : rows), reject);
+  }
+
+  catch(onReject) {
+    return this.then(null, onReject);
   }
 
   toString() {
@@ -207,7 +211,12 @@ class Database {
   query(sql, values) {
     const data = values ? values.join(',') : '';
     this.console.debug(`${sql}\t[${data}]`);
-    return this.pool.query(sql, values);
+
+    return this.pool.query(sql, values).catch((error) => {
+      error.dbStack = error.stack;
+      Error.captureStackTrace(error);
+      throw error;
+    });
   }
 
   register(name, fields, params, data) {

--- a/metasql.d.ts
+++ b/metasql.d.ts
@@ -60,7 +60,11 @@ export class Query {
   desc(field: string | Array<string>): Query;
   limit(count: number): Query;
   offset(count: number): Query;
-  then(resolve: (rows: Array<object>) => void, reject: Function): void;
+  then(
+    resolve?: (rows: Array<object>) => unknown,
+    reject?: Function
+  ): Promise<unknown>;
+  catch(reject?: Function): Promise<unknown>;
   toString(): string;
   toObject(): QueryObject;
   static from(db: Database, metadata: QueryObject): Query;

--- a/test/sql.js
+++ b/test/sql.js
@@ -34,6 +34,21 @@ const metadomain = require('metadomain');
     test.end();
   });
 
+  metatests.test('Database.query error', async (test) => {
+    try {
+      await db.query('INVALID SQL');
+      test.fail('Invalid query should throw an error');
+    } catch (error) {
+      test.assert(
+        error.stack.includes('test/sql.js'),
+        'Error stack should have query invocation file in it'
+      );
+      test.assert(error.dbStack, 'Original error stack should be preserved');
+    } finally {
+      test.end();
+    }
+  });
+
   metatests.test('Database.select', async (test) => {
     const res1 = await db.select('City', ['*'], { cityId: 3 });
     test.strictEqual(res1.length, 1);
@@ -45,6 +60,18 @@ const metadomain = require('metadomain');
     const { cityId, name } = res3[0];
     test.strictEqual(cityId, '1');
     test.strictEqual(name, 'Beijing');
+    test.end();
+  });
+
+  metatests.test('Database.select.then', async (test) => {
+    await db
+      .select('City', ['*'], { cityId: 3 })
+      .then((cities) => cities[0])
+      .then((city) => {
+        test.pass('Sequential then is called properly');
+        test.strictEqual(city, { cityId: '3', name: 'Kiev', countryId: '1' });
+      });
+
     test.end();
   });
 


### PR DESCRIPTION
At the moment error stack is defined by the driver's internal stack from event loop to parsing, which provides little to no actual info on where the error happened.

This PR rewrites the error stack with Node's built-in Error.captureStackTrace.

If this is ok -- I will add info to the CHANGELOG.

- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
- [x] description of changes is added in CHANGELOG.md
