### PR TITLE
Fix setup pg tables from schemas with cross foreign keys

### DIFF
--- a/lib/dbms.js
+++ b/lib/dbms.js
@@ -51,8 +51,10 @@ const getPreviousVersion = async (modelPath) => {
 const create = async (modelPath, outputPath = modelPath) => {
   console.log('Generating SQL DDL script ' + shorten(outputPath));
   const model = await loadModel(modelPath);
-  const modelRemain = {};
-  model.order.forEach((value) => (modelRemain[value] = null));
+  const delayedKeys = {};
+  for (const key of model.order) {
+    delayedKeys[key] = null;
+  }
   const script = [];
   const ins = [];
   const upd = [];
@@ -60,14 +62,14 @@ const create = async (modelPath, outputPath = modelPath) => {
   for (const name of model.order) {
     const entity = model.entities.get(name);
     if (metaschema.KIND_STORED.includes(entity.kind)) {
-      script.push(createEntity(model, name, modelRemain), '');
+      script.push(createEntity(model, name, delayedKeys), '');
       if (model.entities.get('Identifier')) {
         const { inserts, updates } = registerEntity(model, name);
         ins.push(inserts);
         upd.push(updates);
       }
     }
-    delete modelRemain[name];
+    delete delayedKeys[name];
   }
   if (ins.length) script.push(...ins, '', ...upd, '');
   const dbPath = path.join(outputPath, 'database.sql');

--- a/lib/dbms.js
+++ b/lib/dbms.js
@@ -51,9 +51,9 @@ const getPreviousVersion = async (modelPath) => {
 const create = async (modelPath, outputPath = modelPath) => {
   console.log('Generating SQL DDL script ' + shorten(outputPath));
   const model = await loadModel(modelPath);
-  const delayedKeys = {};
+  const delayedKeys = new Map();
   for (const key of model.order) {
-    delayedKeys[key] = null;
+    delayedKeys.set(key, null);
   }
   const script = [];
   const ins = [];
@@ -69,7 +69,7 @@ const create = async (modelPath, outputPath = modelPath) => {
         upd.push(updates);
       }
     }
-    delete delayedKeys[name];
+    delayedKeys.delete(name);
   }
   if (ins.length) script.push(...ins, '', ...upd, '');
   const dbPath = path.join(outputPath, 'database.sql');

--- a/lib/dbms.js
+++ b/lib/dbms.js
@@ -51,6 +51,8 @@ const getPreviousVersion = async (modelPath) => {
 const create = async (modelPath, outputPath = modelPath) => {
   console.log('Generating SQL DDL script ' + shorten(outputPath));
   const model = await loadModel(modelPath);
+  const modelRemain = {};
+  model.order.forEach((value) => (modelRemain[value] = null));
   const script = [];
   const ins = [];
   const upd = [];
@@ -58,13 +60,14 @@ const create = async (modelPath, outputPath = modelPath) => {
   for (const name of model.order) {
     const entity = model.entities.get(name);
     if (metaschema.KIND_STORED.includes(entity.kind)) {
-      script.push(createEntity(model, name), '');
+      script.push(createEntity(model, name, modelRemain), '');
       if (model.entities.get('Identifier')) {
         const { inserts, updates } = registerEntity(model, name);
         ins.push(inserts);
         upd.push(updates);
       }
     }
+    delete modelRemain[name];
   }
   if (ins.length) script.push(...ins, '', ...upd, '');
   const dbPath = path.join(outputPath, 'database.sql');

--- a/lib/pg.js
+++ b/lib/pg.js
@@ -138,7 +138,7 @@ const flatFields = (fields) => {
   return flat;
 };
 
-const createEntity = (model, name) => {
+const createEntity = (model, name, modelRemain = {}) => {
   const entity = model.entities.get(name);
   const sql = [];
   const idx = [];
@@ -183,7 +183,10 @@ const createEntity = (model, name) => {
         const ref = model.entities.get(def.type);
         if (!ref) throw new Error(`Unknown schema: ${def.type}`);
         const refId = ref.kind === 'registry';
-        idx.push(foreignKey(name, field, def, refId));
+        const fKey = foreignKey(name, field, def, refId);
+        if (def.type in modelRemain && def.type !== name) {
+          modelRemain[def.type] = fKey;
+        } else idx.push(fKey);
       }
     }
   }
@@ -201,6 +204,7 @@ const createEntity = (model, name) => {
   }
   sql[sql.length - 1] = sql[sql.length - 1].slice(0, -1);
   sql.push(');');
+  if (modelRemain[name]) idx.push(modelRemain[name]);
   return sql.join('\n') + '\n\n' + idx.join('\n');
 };
 

--- a/lib/pg.js
+++ b/lib/pg.js
@@ -138,7 +138,7 @@ const flatFields = (fields) => {
   return flat;
 };
 
-const createEntity = (model, name, delayedKeys = {}) => {
+const createEntity = (model, name, delayedKeys = new Map()) => {
   const entity = model.entities.get(name);
   const sql = [];
   const idx = [];
@@ -184,8 +184,8 @@ const createEntity = (model, name, delayedKeys = {}) => {
         if (!ref) throw new Error(`Unknown schema: ${def.type}`);
         const refId = ref.kind === 'registry';
         const fKey = foreignKey(name, field, def, refId);
-        if (def.type in delayedKeys && def.type !== name) {
-          delayedKeys[def.type] = fKey;
+        if (delayedKeys.has(def.type) && def.type !== name) {
+          delayedKeys.set(def.type, fKey);
         } else {
           idx.push(fKey);
         }
@@ -206,7 +206,8 @@ const createEntity = (model, name, delayedKeys = {}) => {
   }
   sql[sql.length - 1] = sql[sql.length - 1].slice(0, -1);
   sql.push(');');
-  if (delayedKeys[name]) idx.push(delayedKeys[name]);
+  const delayedKeyCurrent = delayedKeys.get(name);
+  if (delayedKeyCurrent) idx.push(delayedKeyCurrent);
   return sql.join('\n') + '\n\n' + idx.join('\n');
 };
 

--- a/lib/pg.js
+++ b/lib/pg.js
@@ -138,7 +138,7 @@ const flatFields = (fields) => {
   return flat;
 };
 
-const createEntity = (model, name, modelRemain = {}) => {
+const createEntity = (model, name, delayedKeys = {}) => {
   const entity = model.entities.get(name);
   const sql = [];
   const idx = [];
@@ -184,9 +184,11 @@ const createEntity = (model, name, modelRemain = {}) => {
         if (!ref) throw new Error(`Unknown schema: ${def.type}`);
         const refId = ref.kind === 'registry';
         const fKey = foreignKey(name, field, def, refId);
-        if (def.type in modelRemain && def.type !== name) {
-          modelRemain[def.type] = fKey;
-        } else idx.push(fKey);
+        if (def.type in delayedKeys && def.type !== name) {
+          delayedKeys[def.type] = fKey;
+        } else {
+          idx.push(fKey);
+        }
       }
     }
   }
@@ -204,7 +206,7 @@ const createEntity = (model, name, modelRemain = {}) => {
   }
   sql[sql.length - 1] = sql[sql.length - 1].slice(0, -1);
   sql.push(');');
-  if (modelRemain[name]) idx.push(modelRemain[name]);
+  if (delayedKeys[name]) idx.push(delayedKeys[name]);
   return sql.join('\n') + '\n\n' + idx.join('\n');
 };
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->
This pull request fixes an issue that occurs when creating a database from schemas that contain cross foreign keys. When such schemas exist, these foreign keys are added to the SQL script after both related tables have been created. This eliminates the error when a foreign key to a table is attempted to be added before the table has been created.

Fixes #291
- [x] tests and linter show no problems (`npm t`)
- [ ] tests are added/updated for bug fixes and new features
- [ ] code is properly formatted (`npm run fix`)
- [ ] description of changes is added in CHANGELOG.md
- [ ] update .d.ts typings
